### PR TITLE
Load userinfo first with iframe, so autologin works

### DIFF
--- a/index.html
+++ b/index.html
@@ -496,7 +496,7 @@ function prefillUser(data) {
   }
 }
 
-function onload() {
+function onloadUserinfo() {
   $.ajax({
     url: 'https://www.ligfiets.net/userinfo',
     method: 'GET',
@@ -521,7 +521,8 @@ function onload() {
 }
 </script>
 </head>
-<body onload="onload()">
+<body>
+<iframe height="1" width="1" src="https://www.ligfiets.net/userinfo" onload="onloadUserinfo()"></iframe>
 <!-- start page--><div id="page">
 <img src="cvheader2017blauw.png" style="width: 1146px; height:150px"/>
 <!-- start main--><div id="main">


### PR DESCRIPTION
If the session ID cookies has expired, the /userinfo XHR query does not
work, as it is redirected to the autologin page. When loading the URL
first with an iframe, this is performed correctly befor executing the
XHR request to get the relevant user data.